### PR TITLE
fix : invert color of results text in dark mode

### DIFF
--- a/src/components/Charts/Chart.vue
+++ b/src/components/Charts/Chart.vue
@@ -89,3 +89,9 @@
     },
   };
 </script>
+
+<style>
+  [data-theme='dark'] .ct-label {
+    filter: invert(1) !important;
+  }
+</style>


### PR DESCRIPTION
# Description

Text used in the schema for X and Y coordinates was not readable enough in dark mode. This pull request change the color of the text from black to white. 

Fixes # (issue)

## Type of change

- *[x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- *[x] My code follows the style guidelines of this project
- *[ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- *[ ] I have checked responsive design
- [ ] I have added or updated translations for all languages
- *[ ] My changes generate no new warnings

