### PR TITLE
fix: update color in dark theme for select diagram modal

### DIFF
--- a/src/components/ApiRequest/DiagramChoice.vue
+++ b/src/components/ApiRequest/DiagramChoice.vue
@@ -84,6 +84,9 @@
   .modal-item:hover {
     background-color: #f5f5f5;
   }
+  [data-theme='dark'] .modal-item:hover {
+    background-color: #4e5666;
+  }
   .modal-item img {
     width: 6rem;
     height: 6rem;


### PR DESCRIPTION
# Description

In dark mode, when you select a type of diagram, the background becomes white, and you can no longer see the text. This pull request uses an appropriate color. 

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have checked responsive design
- [ ] I have added or updated translations for all languages
- [x] My changes generate no new warnings

